### PR TITLE
fix(deploy): избежать поломки sed на значениях с '/' в .env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,19 +15,33 @@ jobs:
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          DATABASE_USER: ${{ secrets.DATABASE_USER }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+          CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
+          APP_VERSION: ${{ github.ref_name }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: 22
+          envs: DATABASE_USER,DATABASE_PASSWORD,DATABASE_HOST,CORS_ALLOWED_ORIGINS,APP_VERSION
           script: |
             cd ${{ secrets.SSH_PATH_TO_APP }}/api/
             cp .env.example .env
-            sed -i.bak 's/^DATABASE_USER=.*/DATABASE_USER=${{ secrets.DATABASE_USER }}/' .env
-            sed -i.bak 's/^DATABASE_PASSWORD=.*/DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}/' .env
-            sed -i.bak 's/^DATABASE_HOST=.*/DATABASE_HOST=${{ secrets.DATABASE_HOST }}/' .env
-            sed -i.bak 's/^APP_VERSION=.*/APP_VERSION=${{ github.ref_name }}/' .env
-            sed -i.bak 's/^APP_SECRET=.*/APP_ENV=production/' .env
-            sed -i.bak 's/^CORS_ALLOWED_ORIGINS=.*/CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}/' .env
+
+            set_env() {
+              grep -v "^$1=" .env > .env.tmp && mv .env.tmp .env
+              echo "$1=$2" >> .env
+            }
+
+            set_env DATABASE_USER "$DATABASE_USER"
+            set_env DATABASE_PASSWORD "$DATABASE_PASSWORD"
+            set_env DATABASE_HOST "$DATABASE_HOST"
+            set_env APP_VERSION "$APP_VERSION"
+            set_env APP_ENV "production"
+            set_env CORS_ALLOWED_ORIGINS "$CORS_ALLOWED_ORIGINS"
+
             cd ../infra-docker/
             make deploy-api-tag TAG=${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Секреты в `deploy.yml` (в т.ч. `CORS_ALLOWED_ORIGINS` с URL) подставлялись как сырой текст прямо в `sed s/.../.../`, из-за чего `/` в значении ломал разделитель sed-команды.
- Секреты теперь прокидываются на удалённый хост через нативные `env:`/`envs:` входы `appleboy/ssh-action`, вместо YAML-интерполяции в тексте `script:`.
- Замена строк в `.env` переведена с `sed` на `grep -v` + `echo`, устойчивую к любым символам в значении.
- Попутно исправлен смежный баг: `sed 's/^APP_SECRET=.*/APP_ENV=production/'` искал несуществующий паттерн `APP_SECRET` и мог не сработать.

Closes #9

## Test plan
- [ ] Прогнать workflow `Deploy` (workflow_dispatch) на тестовом сервере и проверить, что `.env` содержит корректный `CORS_ALLOWED_ORIGINS=https://...` без ошибок sed
- [ ] Проверить, что `DATABASE_USER/PASSWORD/HOST`, `APP_VERSION`, `APP_ENV` также корректно попадают в `.env`
- [ ] Убедиться, что секреты остаются замаскированными в логах Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)